### PR TITLE
Switch to maintained fork of ng-annotate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ module.exports = {
 }
 ```
 
+Since version 0.4.1: switched to maintained fork of `ng-annotate`: [ng-annotate-patched](https://github.com/bluetech/ng-annotate-patched) to benefit from its improvements.
+
 Since version 0.4.0: for performance reasons, chunks where the name starts with `vendors~` are not
 annotated. To customize this behavior, set the option `annotateChunk` to a method that returns
 `true` if a chunk should be annotated:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-var ngAnnotate = require('ng-annotate'),
+var ngAnnotate = require('ng-annotate-patched'),
     SourceMapSource = require('webpack-core/lib/SourceMapSource');
 
 function ngAnnotatePlugin(options) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-annotate-webpack-plugin",
-  "version": "0.4.0",
-  "description": "webpack plugin that runs ng-annotate on your bundles",
+  "version": "0.4.1",
+  "description": "webpack plugin that runs ng-annotate-patched on your bundles",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/cliechty/ng-annotate-webpack-plugin",
   "dependencies": {
-    "ng-annotate": "^1.2.1",
+    "ng-annotate-patched": "^1.11.1",
     "webpack-core": "^0.6.5"
   }
 }


### PR DESCRIPTION
To benefit from the improvements of the maintained fork of ng-annotate, switching dependency to ng-annotate-patched was implemented. 

In my case, I was running into OOM issues when using the original implementation.